### PR TITLE
ATOS-with-Nginx.md: add proxy_pass to restricted location

### DIFF
--- a/pages/JATOS-with-Nginx.md
+++ b/pages/JATOS-with-Nginx.md
@@ -93,8 +93,9 @@ http {
 
                 # restrict access to JATOS' GUI to local network
                 #location /jatos {
-                #       allow   192.168.1.0/24;
-                #       deny    all;
+                #       allow           192.168.1.0/24;
+                #       deny            all;
+                #       proxy_pass      http://jatos-backend;
                 #}
 
                 # all other traffic
@@ -168,8 +169,9 @@ http {
 
                 # restrict access to JATOS' GUI to local network
                 #location /jatos {
-                #       allow   192.168.1.0/24;
-                #       deny    all;
+                #       allow           192.168.1.0/24;
+                #       deny            all;
+                #       proxy_pass      http://jatos-backend;
                 #}
 
                 # all other traffic


### PR DESCRIPTION
If we don't add proxy_pass it will always return 404 not found, when the user ip is in the allow range.