### PR TITLE
Do not grant MySQL user access to all databases

### DIFF
--- a/pages/JATOS-with-MySQL.md
+++ b/pages/JATOS-with-MySQL.md
@@ -39,26 +39,26 @@ There are many manuals out there, e.g. [this one](https://www.digitalocean.com/c
       mysql -u root -p
       ```
    
-   1. Create a user for JATOS: 
-   
-      You can use any username and password but have to remember them when configuring JATOS later on.
-
-      ```bash
-      GRANT ALL PRIVILEGES ON *.* TO 'jatosuser'@'localhost' IDENTIFIED BY 'password';
-      ```
-   
-   1. Log out and log in with the newly created user:
-   
-      ```bash
-      mysql -u jatosuser -p
-      ```
-   
    1. Create a database for JATOS:
 
       **Character set and collation are important - otherwise you won't have full UTF-8 support**
    
       ```bash
       CREATE DATABASE jatos CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      ```
+   
+   1. Create a user for JATOS: 
+   
+      You can use any username and password but have to remember them when configuring JATOS later on.
+
+      ```bash
+      GRANT ALL PRIVILEGES ON jatos.* TO 'jatosuser'@'localhost' IDENTIFIED BY 'password';
+      ```
+   
+   1. Log out and log in with the newly created user:
+   
+      ```bash
+      mysql -u jatosuser -p
       ```
    
    1. Exit the database with `exit`


### PR DESCRIPTION
Do not recommend granting ALL privileges on ALL MySQL databases on the server, like this:

    GRANT ALL PRIVILEGES ON *.* TO 'jatosuser'@'localhost' IDENTIFIED BY 'password';

Instead create the database first and then grant ALL privileges only on the jatos database, like this:

    GRANT ALL PRIVILEGES ON jatos.* TO 'jatosuser'@'localhost' IDENTIFIED BY 'password';

I had 10+ other database on my MySQL server, which the jatos user shouldn't get access to.